### PR TITLE
fix: exclude anonymously hosted dll

### DIFF
--- a/Mykeels.CSharpRepl/Configuration.cs
+++ b/Mykeels.CSharpRepl/Configuration.cs
@@ -104,6 +104,7 @@ public sealed class Configuration
                 .ToArray()
         )
         .Concat(ReferenceManager.GetReferencePaths())
+        .Where(r => !r.Contains("Anonymously Hosted DynamicMethods Assembly.dll"))
         .ToHashSet();
         Usings = (usings?.ToHashSet() ?? []).Concat([
             "System",

--- a/Mykeels.CSharpRepl/Mykeels.CSharpRepl.csproj
+++ b/Mykeels.CSharpRepl/Mykeels.CSharpRepl.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
# What Changed?

Exclude a problematic dll