### PR TITLE
fix: update dotnetRuntimePath to use DOTNET_ROOT environment variable

### DIFF
--- a/Mykeels.CSharpRepl/Roslyn/References/DotNetInstallationLocator.cs
+++ b/Mykeels.CSharpRepl/Roslyn/References/DotNetInstallationLocator.cs
@@ -31,7 +31,7 @@ internal sealed class DotNetInstallationLocator
             logger: logger,
             io: new FileSystem(),
             // a path like C:\Program Files\dotnet
-            dotnetRuntimePath: Path.GetFullPath(
+            dotnetRuntimePath: Environment.GetEnvironmentVariable("DOTNET_ROOT") ?? Path.GetFullPath(
                 Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), "../../../")
             ),
             // a path like C:\Users\username


### PR DESCRIPTION
# What Changed?

This pull request updates the logic for locating the .NET runtime path in the `DotNetInstallationLocator` constructor. The change makes the application respect the `DOTNET_ROOT` environment variable if it is set, improving compatibility with custom .NET installations.

Improvements to .NET runtime path detection:

* [`Mykeels.CSharpRepl/Roslyn/References/DotNetInstallationLocator.cs`](diffhunk://#diff-b3ac362aaed131cf059dcc00972d7a4d01152b2095f4b529b9f3f07807d5085fL34-R34): Updated the `dotnetRuntimePath` assignment to first check for the `DOTNET_ROOT` environment variable, falling back to the previous path calculation if it is not set.